### PR TITLE
Implement multi-platform Docker builds with Parity-style approach

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    # Use matrix strategy to build each architecture separately (saves ~8GB disk space per build)
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: write  # Changed from read to write to allow pushing commits
@@ -187,11 +183,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      - name: Set up QEMU (for cross-platform emulation)
-        if: matrix.platform == 'linux/arm64'
+      # Set up QEMU for ARM64 emulation
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: linux/arm64
       
       # ------------------------------------------------------------
       # BOOTNODE PEER ID CONFIGURATION
@@ -1108,7 +1104,6 @@ jobs:
           echo "✅ All chainspecs verified successfully"
 
       - name: Upload chain specs as artifacts
-        if: matrix.platform == 'linux/amd64'  # Only upload once since chainspecs are platform-independent
         uses: actions/upload-artifact@v4
         with:
           name: fennel-chainspecs
@@ -1124,42 +1119,15 @@ jobs:
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      
-      # Aggressive cleanup before Docker build to maximize available space
-      - name: Pre-build cleanup to maximize disk space
-        run: |
-          echo "=== Pre-build space optimization ==="
-          df -h
-          
-          # Remove large unnecessary files
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android || true
-          sudo rm -rf /usr/local/.ghcup /home/linuxbrew || true
-          
-          # Clean package caches
-          sudo apt-get clean
-          sudo apt-get autoremove -y
-          
-          # Remove Docker cache and images
-          docker system prune -af --volumes || true
-          
-          # Remove all previous Rust build artifacts
-          rm -rf target/ ~/.cargo/registry/cache/ ~/.cargo/git/db/ || true
-          
-          # Clear tmp and logs
-          sudo rm -rf /tmp/* /var/log/* || true
-          
-          echo "=== Space after cleanup ==="
-          df -h
-      
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}   # 🟢 Build one platform per runner
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             WASM_HASH=${{ env.WASM_HASH }}
           # Remove problematic cache settings that are causing the blob error
@@ -1180,13 +1148,13 @@ jobs:
       - name: Upload Docker image info artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fennel-node-image-info-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: fennel-node-image-info
           path: ./artifacts/image-info.txt
 
       - name: Upload node binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fennel-node-binary-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: fennel-node-binary
           path: |
             ${{ steps.pkg_node.outputs.tarball }}
             ${{ steps.pkg_node.outputs.tarball }}.sha256
@@ -1383,7 +1351,6 @@ jobs:
             ${{ steps.raw_binary.outputs.binary_sha256 }}
           generate_release_notes: true
           fail_on_unmatched_files: true
-          overwrite_files: true
           body: |
             ## 🚀 Fennel Node ${{ github.ref_name }}
 
@@ -1435,7 +1402,6 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Upload Helm chart artifact
-        if: matrix.platform == 'linux/amd64'  # Only upload once since Helm charts are platform-independent
         uses: actions/upload-artifact@v4
         with:
           name: fennel-helm-chart

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,8 @@ docs/original githubactions workflow.txt
 ACT_TESTING_SUMMARY.md
 .secrets
 test-workflow.sh
+dockerfiles/
+Makefile
 
 # Kubernetes artifacts
 *.kubeconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,78 +1,29 @@
-# syntax=docker/dockerfile:1
+FROM docker.io/paritytech/ci-unified:latest as base
 
-# ---- common ARGs -------------------------------------------------
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
-# ------------------------------------------------------------------
-
-####################  🍳  BUILDER  ####################
-FROM --platform=$BUILDPLATFORM docker.io/paritytech/ci-unified:latest AS builder
-ARG TARGETPLATFORM
 WORKDIR /fennel
 
-# Upgrade Rust to latest stable (>=1.85.0, which supports edition2024)
-RUN rustup update stable
-
-# --- Use system libraries to avoid compiling massive C/C++ codebases ---------------
-# Note: Removed librocksdb-dev because system version is too old (7.x vs required 8.x)
-# We'll use vendored/static RocksDB build instead
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    binaryen \
-    && rm -rf /var/lib/apt/lists/*
-
-# --- cross-toolchain for Arm64 (only when needed) ---------------
-ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends \
-        gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-        libc6-dev-arm64-cross libstdc++-10-dev-arm64-cross \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
-# Tell cc-rs / bindgen where the headers live + use system libraries where possible
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-    AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
-    BINARYEN_SYSTEM_LIB=1 \
-    ROCKSDB_STATIC=1
-
-# Cargo-chef (one install is enough for both legs)
-RUN cargo install cargo-chef
-
-# Add WASM target for both platforms
-RUN rustup target add wasm32-unknown-unknown
+# Install cargo-chef and pre-fetch the wasm target once
+RUN cargo install cargo-chef \
+    && rustup target add wasm32-unknown-unknown
 
 # Optimize cargo for space and reduce compilation units
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_INCREMENTAL=0
 ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 ENV CARGO_PROFILE_RELEASE_LTO=true
-# Reduce memory usage and disk space during builds
-ENV CARGO_PROFILE_RELEASE_DEBUG=0
-ENV CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off
-ENV CARGO_TARGET_DIR=/tmp/target
-# Set workspace hint for WASM builds
-ENV WASM_BUILD_WORKSPACE_HINT=/fennel
 
 # Planner stage - analyze dependencies
-FROM builder AS planner
+FROM base AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Testing stage - run tests before building (only on native platform for speed)
-FROM builder AS tester
+# Testing stage - run tests before building
+FROM base AS tester
 COPY . .
-# Only run tests on AMD64 to save build time, tests are architecture-independent for Substrate
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        cargo test --features=runtime-benchmarks; \
-    else \
-        echo "Skipping tests on $TARGETPLATFORM (tests run on amd64 only)"; \
-    fi
+RUN cargo test --features=runtime-benchmarks
 
 # --- New stage: deterministic WASM runtime build using srtool -----------------
-# Note: srtool produces architecture-independent WASM, so we only build on amd64
-FROM --platform=linux/amd64 docker.io/paritytech/srtool:1.84.1 AS srtool
-ARG TARGETPLATFORM
+FROM docker.io/paritytech/srtool:1.84.1 AS srtool
 
 # The srtool image expects the sources to live in /build
 WORKDIR /build
@@ -87,75 +38,51 @@ ENV PACKAGE=fennel-node-runtime
 
 # Build the runtime in deterministic mode. The build script lives inside the
 # image under /scripts/build
-# Only build WASM on AMD64 since it's architecture-independent
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        /srtool/build; \
-    else \
-        echo "Skipping srtool build on $TARGETPLATFORM (WASM built on amd64 only)"; \
-        mkdir -p runtime/fennel/target/srtool/release/wbuild/fennel-node-runtime; \
-        touch runtime/fennel/target/srtool/release/wbuild/fennel-node-runtime/fennel_node_runtime.compact.wasm; \
-    fi
+RUN /srtool/build
 
 # The compact deterministic wasm will be available below.
-ENV DETERMINISTIC_WASM_PATH=runtime/fennel/target/srtool/release/wbuild/fennel-node-runtime/fennel_node_runtime.compact.wasm
+ENV DETERMINISTIC_WASM_PATH=target/srtool/release/wbuild/fennel-node-runtime/fennel_node_runtime.compact.wasm
 
-# ---------------  Back to builder for final compilation  -----------------
-FROM builder AS compiler
-ARG TARGETPLATFORM
-
-# Map Docker platform → Rust triple **once** and persist it
-RUN case "$TARGETPLATFORM" in \
-      linux/arm64) RUST_TARGET=aarch64-unknown-linux-gnu ;; \
-      linux/amd64) RUST_TARGET=x86_64-unknown-linux-gnu   ;; \
-      *) echo "Unsupported $TARGETPLATFORM" && exit 1 ;; \
-    esac && \
-    echo "Installing target $RUST_TARGET…" && \
-    rustup target add --toolchain stable "$RUST_TARGET" && \
-    echo "RUST_TARGET=$RUST_TARGET" >> /etc/environment
-
-# ---------------  dependency cache  -----------------
+# Builder stage - build with cached dependencies
+FROM base AS builder
 COPY --from=planner /fennel/recipe.json recipe.json
-# ensure std is present in *this* layer too
-RUN . /etc/environment && \
-    rustup target list --installed | grep -q "$RUST_TARGET" || rustup target add "$RUST_TARGET" && \
-    # Use system libraries where possible, static RocksDB
-    export BINARYEN_SYSTEM_LIB=1 && \
-    export ROCKSDB_STATIC=1 && \
-    cargo chef cook --release --target $RUST_TARGET --recipe-path recipe.json && \
-    # Clean up intermediate artifacts to save space
-    find /tmp/target -name "*.rlib" -type f -delete && \
-    find /tmp/target -name "*.rmeta" -type f -delete && \
-    find /tmp/target -name "*.o" -type f -delete && \
-    find /tmp/target -name "*.a" -type f -delete || true
 
-# ---------------  final build  ----------------------
+# Build dependencies first (this layer will be cached)
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Now copy the actual source code and build
 COPY . .
-RUN . /etc/environment && \
-    # ensure std is present in *this* layer too \
-    rustup target list --installed | grep -q "$RUST_TARGET" || rustup target add "$RUST_TARGET" && \
-    echo "Building for target: $RUST_TARGET" && \
-    # Use system libraries where possible, static RocksDB
-    export BINARYEN_SYSTEM_LIB=1 && \
-    export ROCKSDB_STATIC=1 && \
-    # Use CARGO_TARGET_DIR to build in /tmp and clean as we go
-    cargo build --locked --release --target=$RUST_TARGET && \
-    mkdir -p /out && \
-    install -Dm755 /tmp/target/$RUST_TARGET/release/fennel-node /out/fennel-node && \
-    # Aggressive cleanup to free disk space immediately
-    rm -rf /tmp/target ~/.cargo/registry ~/.cargo/git
+RUN cargo build --locked --release
 
-####################  🏃  RUNTIME  ####################
-FROM --platform=$TARGETPLATFORM docker.io/parity/base-bin:latest
-ARG TARGETPLATFORM
+# Runtime stage - final image with minimal components
+FROM docker.io/parity/base-bin:latest
 
-# Choose the right sub-directory and copy the binary
-COPY --from=compiler /out/fennel-node /usr/local/bin/fennel-node
+# Copy the node binary
+COPY --from=builder /fennel/target/release/fennel-node /usr/local/bin/fennel-node
 
-# Copy the deterministic WASM (optional, may fail on ARM64 builds where srtool doesn't run)
+# Copy the deterministic wasm compiled with srtool (optional but convenient for
+# governance upgrades & CI verification)
 COPY --from=srtool /build/runtime/fennel/target/srtool/release/wbuild/fennel-node-runtime/fennel_node_runtime.compact.wasm /usr/local/bin/fennel_node_runtime.compact.wasm
+RUN test -f /usr/local/bin/fennel_node_runtime.compact.wasm
 
-# Expose standard Substrate ports
+ARG WASM_HASH=unknown
+LABEL io.parity.srtool.wasm-hash=${WASM_HASH}
+
+USER root
+RUN useradd -m -u 1001 -U -s /bin/sh -d /fennel fennel && \
+	mkdir -p /data /fennel/.local/share && \
+	chown -R fennel:fennel /data && \
+	ln -s /data /fennel/.local/share/fennel && \
+# check if executable works in this container
+	/usr/local/bin/fennel-node --version
+
+USER fennel
+
 EXPOSE 9933 9944 30333 9615
+# Removed ports:
+# - 9930: Removed unless specific reverse-proxy need (ecosystem standard)
+# - 30334: Removed - only needed for relay-within-relay processes
 VOLUME ["/data"]
 
+# Use node binary as entrypoint (Parity standard practice)
 ENTRYPOINT ["/usr/local/bin/fennel-node"]


### PR DESCRIPTION
🚀 Key Changes:
- Updated GitHub Actions workflow to use single-job multi-platform builds
- Removed matrix strategy that was causing ARM64 manifest overwrites
- Simplified Dockerfile following Parity's buildx/QEMU approach
- Removed complex cross-compilation toolchains in favor of buildx emulation
- Updated workflow to build linux/amd64,linux/arm64 with automatic manifest list
- Added dockerfiles/ and Makefile to .gitignore for local testing

🔧 Technical Details:
- Uses docker/build-push-action@v6 with platforms: linux/amd64,linux/arm64
- Relies on Parity's ci-unified base image and buildx platform switching
- Eliminates race conditions between platform builds
- Follows Polkadot ecosystem standards for multi-platform container builds

This should resolve ARM64 manifest missing from ghcr.io/corruptedaesthetic/fennel-solonet