### PR TITLE
ci: fix non-fast-forward push failures with fetch+rebase strategy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -718,6 +718,10 @@ jobs:
             - Bootnode 1: $BOOTNODE1_PEER_ID
             - Bootnode 2: $BOOTNODE2_PEER_ID"
             
+            # Fetch latest main and rebase our changes on top
+            git fetch origin main
+            git rebase origin/main
+            
             # Push the changes back to the repository (push current HEAD to main branch)
             git push origin HEAD:main
             
@@ -846,6 +850,10 @@ jobs:
             - Using external-only bootnode architecture (Parity best practice)
             - Bootnode 1: $BOOTNODE1_PEER_ID
             - Bootnode 2: $BOOTNODE2_PEER_ID"
+            
+            # Fetch latest main and rebase our changes on top
+            git fetch origin main
+            git rebase origin/main
             
             # Push the changes back to the repository (push current HEAD to main branch)
             git push origin HEAD:main
@@ -1039,6 +1047,10 @@ jobs:
             - Chainspec contains placeholder validator keys
             - Real validator and bootnode keys managed via HashiCorp Vault
             - Production deployment uses offline-generated keys"
+            
+            # Fetch latest main and rebase our changes on top
+            git fetch origin main
+            git rebase origin/main
             
             # Push the changes back to the repository (push current HEAD to main branch)
             git push origin HEAD:main


### PR DESCRIPTION
- Replace git pull --rebase with git fetch + git rebase for better reliability
- Ensures chainspec commits are properly rebased on latest main before push
- Fixes detached HEAD state issues when pushing from tag-triggered workflows